### PR TITLE
Expose decoded frame's binary sizes

### DIFF
--- a/src/main/java/com/datastax/oss/protocol/internal/Frame.java
+++ b/src/main/java/com/datastax/oss/protocol/internal/Frame.java
@@ -36,6 +36,8 @@ public class Frame {
         streamId,
         tracing,
         null,
+        -1,
+        -1,
         customPayload,
         Collections.emptyList(),
         message);
@@ -49,7 +51,16 @@ public class Frame {
       List<String> warnings,
       Message message) {
     return new Frame(
-        protocolVersion, false, streamId, false, tracingId, customPayload, warnings, message);
+        protocolVersion,
+        false,
+        streamId,
+        false,
+        tracingId,
+        -1,
+        -1,
+        customPayload,
+        warnings,
+        message);
   }
 
   public final int protocolVersion;
@@ -71,6 +82,23 @@ public class Frame {
    */
   public final boolean tracing;
 
+  /**
+   * The binary size of the frame in bytes (including the header).
+   *
+   * <p>This is exposed for information purposes, and only for instances returned by the frame
+   * decoder. Otherwise, it is set to -1.
+   */
+  public final int size;
+
+  /**
+   * The binary size of the compressed frame (including the header).
+   *
+   * <p>This is exposed for information purposes, and only for instances returned by the frame
+   * decoder, <b>if compression is enabled and the frame was compressed when it was received</b>.
+   * Otherwise, it is set to -1.
+   */
+  public final int compressedSize;
+
   public final Map<String, ByteBuffer> customPayload;
   public final List<String> warnings;
   public final Message message;
@@ -86,6 +114,8 @@ public class Frame {
       int streamId,
       boolean tracing,
       UUID tracingId,
+      int size,
+      int compressedSize,
       Map<String, ByteBuffer> customPayload,
       List<String> warnings,
       Message message) {
@@ -96,8 +126,34 @@ public class Frame {
     this.streamId = streamId;
     this.tracingId = tracingId;
     this.tracing = tracing;
+    this.size = size;
+    this.compressedSize = compressedSize;
     this.customPayload = customPayload;
     this.warnings = warnings;
     this.message = message;
+  }
+
+  /** @deprecated maintain compatibility while Simulacron upgrades to the latest native-protocol. */
+  @Deprecated
+  public Frame(
+      int protocolVersion,
+      boolean beta,
+      int streamId,
+      boolean tracing,
+      UUID tracingId,
+      Map<String, ByteBuffer> customPayload,
+      List<String> warnings,
+      Message message) {
+    this(
+        protocolVersion,
+        beta,
+        streamId,
+        tracing,
+        tracingId,
+        -1,
+        -1,
+        customPayload,
+        warnings,
+        message);
   }
 }

--- a/src/main/java/com/datastax/oss/protocol/internal/FrameCodec.java
+++ b/src/main/java/com/datastax/oss/protocol/internal/FrameCodec.java
@@ -243,6 +243,16 @@ public class FrameCodec<B> {
       }
     }
 
+    int frameSize;
+    int compressedFrameSize;
+    if (decompressed) {
+      frameSize = headerEncodedSize() + primitiveCodec.sizeOf(source);
+      compressedFrameSize = headerEncodedSize() + length; // what we measured before decompressing
+    } else {
+      frameSize = headerEncodedSize() + length;
+      compressedFrameSize = -1;
+    }
+
     boolean isTracing = Flags.contains(flags, ProtocolConstants.FrameFlag.TRACING);
     UUID tracingId = (isResponse && isTracing) ? primitiveCodec.readUuid(source) : null;
 
@@ -266,7 +276,16 @@ public class FrameCodec<B> {
     }
 
     return new Frame(
-        protocolVersion, beta, streamId, isTracing, tracingId, customPayload, warnings, response);
+        protocolVersion,
+        beta,
+        streamId,
+        isTracing,
+        tracingId,
+        frameSize,
+        compressedFrameSize,
+        customPayload,
+        warnings,
+        response);
   }
 
   private int readStreamId(B source) {

--- a/src/test/java/com/datastax/oss/protocol/internal/RequestFrameCodecTest.java
+++ b/src/test/java/com/datastax/oss/protocol/internal/RequestFrameCodecTest.java
@@ -96,6 +96,11 @@ public class RequestFrameCodecTest extends FrameCodecTestBase {
     assertThat(frame.streamId).isEqualTo(STREAM_ID);
     assertThat(frame.tracing).isEqualTo(tracing);
     assertThat(frame.tracingId).isNull(); // always for requests
+    // Always the same because our mock primitive codec always measures the same size, but in
+    // reality it would change when compressed:
+    assertThat(frame.size).isEqualTo(9 + MockPrimitiveCodec.MOCK_SIZE);
+    assertThat(frame.compressedSize)
+        .isEqualTo((compressor.algorithm() == null) ? -1 : 9 + MockPrimitiveCodec.MOCK_SIZE);
     assertThat(frame.customPayload).isEqualTo(customPayload);
     assertThat(frame.message).isEqualTo(Options.INSTANCE);
   }

--- a/src/test/java/com/datastax/oss/protocol/internal/ResponseFrameCodecTest.java
+++ b/src/test/java/com/datastax/oss/protocol/internal/ResponseFrameCodecTest.java
@@ -107,6 +107,11 @@ public class ResponseFrameCodecTest extends FrameCodecTestBase {
     assertThat(frame.streamId).isEqualTo(streamId);
     assertThat(frame.tracing).isEqualTo(tracing);
     assertThat(frame.tracingId).isEqualTo(tracing ? TRACING_ID : null);
+    // Always the same because our mock primitive codec always measures the same size, but in
+    // reality it would change when compressed:
+    assertThat(frame.size).isEqualTo(9 + MockPrimitiveCodec.MOCK_SIZE);
+    assertThat(frame.compressedSize)
+        .isEqualTo((compressor.algorithm() == null) ? -1 : 9 + MockPrimitiveCodec.MOCK_SIZE);
     assertThat(frame.customPayload).isEqualTo(customPayload);
     assertThat(frame.warnings).isEqualTo(warnings);
     assertThat(frame.message).isInstanceOf(Ready.class);

--- a/src/test/java/com/datastax/oss/protocol/internal/binary/MockCompressor.java
+++ b/src/test/java/com/datastax/oss/protocol/internal/binary/MockCompressor.java
@@ -26,7 +26,6 @@ public class MockCompressor implements Compressor<MockBinaryString> {
 
   @Override
   public String algorithm() {
-    // Implemented for consistency, but the tests don't call this method
     return "MOCK";
   }
 
@@ -45,6 +44,6 @@ public class MockCompressor implements Compressor<MockBinaryString> {
     assertThat(element.type).isEqualTo(MockBinaryString.Element.Type.STRING);
     assertThat(element.value).isEqualTo(END);
 
-    return compressed;
+    return compressed.copy();
   }
 }


### PR DESCRIPTION
Uncompressed size + compressed size if compression was enabled.